### PR TITLE
Add: 답장 버튼 관련 redux세팅

### DIFF
--- a/src/components/ChatForm.tsx
+++ b/src/components/ChatForm.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
-import type { CommentInfo } from '../modules/comments';
+import type { CommentInfo } from '../modules/comments/types';
 import ChatBox from './chatBox/ChatBox';
 import ChatTitle from './chatBox/ChatTitle';
 import Button from './common/Button';
@@ -26,6 +26,7 @@ const test = (comments: CommentInfo[]): boolean => {
 const ChatForm: FC<ChatFormProps> = ({ comments, addCommentInfo, deleteCommentInfo, responseCommentInfo }) => {
   const [commentContent, setCommentContent] = useState<string>('');
   const [isAwaitResponse, setIsAwaitResponse] = useState<boolean>(false);
+  const [responseBtnOn, setResponseBtnOn] = useState(false);
 
   const changeContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const currentContent = e.target.value;
@@ -48,6 +49,7 @@ const ChatForm: FC<ChatFormProps> = ({ comments, addCommentInfo, deleteCommentIn
     <Container>
       <ChatTitle />
       <ChatBox />
+      {responseBtnOn && <p>답장 Btn onClick시 (해당하는 내용)이 보여집니다</p>}
       <ChatInputContainer>
         <ChatInput
           value={commentContent}

--- a/src/components/chatBox/ChatBox.tsx
+++ b/src/components/chatBox/ChatBox.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../modules';
 import ChatBubble from './ChatBubble';
-import { CommentsInfoState, CommentInfo } from '../../modules/comments';
+import { CommentsInfoState, CommentInfo } from '../../modules/comments/types';
 
 const ChatBox = () => {
   const data = useSelector((state: RootState) => state.comments);

--- a/src/components/chatBox/ChatBubble.tsx
+++ b/src/components/chatBox/ChatBubble.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import comments from '../../modules/comments/reducer';
-import { CommentsInfoState, CommentInfo } from '../../modules/comments';
+import { CommentsInfoState, CommentInfo } from '../../modules/comments/types';
 import Button from '../common/Button';
 import { RootState } from '../../modules';
 

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
-import { deleteComment } from '../../modules/comments';
+import { deleteComment, responseComment } from '../../modules/comments/actions';
 
 interface Props {
   messageId: number;
@@ -22,10 +22,14 @@ const CustomButton = styled.button`
 const Button = ({ messageId, buttonType }: Props) => {
   const dispatch = useDispatch();
   const deleteMessage = useCallback((messageId: number) => dispatch(deleteComment(messageId)), [dispatch]);
+  const responseMessage = useCallback((messageId: number) => dispatch(responseComment(messageId)), [dispatch]);
 
   const handlerFunction = (): void => {
     if (buttonType === '삭제') {
       deleteMessage(messageId);
+    } else {
+      // 답장 클릭 시에 messageId뽑아오기
+      responseMessage(messageId);
     }
   };
 

--- a/src/containers/CommentsLoader.tsx
+++ b/src/containers/CommentsLoader.tsx
@@ -1,19 +1,19 @@
 import React, { FC } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { addComment, deleteComment } from '../modules/comments';
+import { addComment, deleteComment } from '../modules/comments/actions';
 import ChatFromTemplate from '../components/ChatFromTemplate';
 import ChatForm from '../components/ChatForm';
 // import { createDate } from '../utils/createDate';
 import userInfo from '../data/tmpUser.json';
 import type { RootState } from '../modules/index';
-import type { CommentInfo } from '../modules/comments';
+import type { CommentInfo } from '../modules/comments/types';
 import SendDate from '../utils/SendDate';
 
 const CommentsLoader: FC = () => {
   const comments = useSelector((state: RootState) => state.comments);
   const dispatch = useDispatch();
 
-  const addCommentInfo = (content: string, keyCode: string) => {
+  const addCommentInfo = (content: string, keyCode: string, responseId?: number) => {
     if (content === '') return;
 
     if (keyCode === 'Enter' || keyCode === '') {
@@ -22,15 +22,25 @@ const CommentsLoader: FC = () => {
       const date = SendDate();
       // const responseId: 답장 버튼 클리식 여기주기 답장 Id주기;
 
-      const commentInfo: CommentInfo = {
-        ...user,
-        date,
-        content,
-        messageId,
-        responseId: null,
-      };
-
-      dispatch(addComment(commentInfo));
+      if (responseId) {
+        const commentInfo: CommentInfo = {
+          ...user,
+          date,
+          content,
+          messageId,
+          responseId,
+        };
+        dispatch(addComment(commentInfo));
+      } else {
+        const commentInfo: CommentInfo = {
+          ...user,
+          date,
+          content,
+          messageId,
+          responseId: null,
+        };
+        dispatch(addComment(commentInfo));
+      }
     }
   };
 

--- a/src/modules/comments/actions.ts
+++ b/src/modules/comments/actions.ts
@@ -3,17 +3,17 @@ import type { CommentInfo } from './types';
 
 export const ADD_COMMENT = 'comments/ADD_COMMENT' as const;
 export const DELETE_COMMENT = 'comments/DELETE_COMMENT';
-export const RESPONSE_COMMENT = 'comments/RESPONSE_COMMENT';
+export const RESPONSE_COMMENT = 'response/RESPONSE_COMMENT';
 
 let nextId = 5;
 
 export const addComment = (commentInfo: CommentInfo) => ({
-    type: ADD_COMMENT,
-    payload: {
-        ...commentInfo,
-        messageId: ++nextId
-    }
-})
+  type: ADD_COMMENT,
+  payload: {
+    ...commentInfo,
+    messageId: ++nextId,
+  },
+});
 
 export const deleteComment = createAction(DELETE_COMMENT)<number>();
-// export const responseComment = createAction(RESPONSE_COMMENT)<CommentInfo, ResponseInfo>();
+export const responseComment = createAction(RESPONSE_COMMENT)<number>();

--- a/src/modules/comments/index.ts
+++ b/src/modules/comments/index.ts
@@ -1,2 +1,0 @@
-export * from './actions';
-export * from './types';

--- a/src/modules/comments/responseReducer.ts
+++ b/src/modules/comments/responseReducer.ts
@@ -1,0 +1,18 @@
+import { createReducer } from 'typesafe-actions';
+import { RESPONSE_COMMENT } from './actions';
+import { ResponseAction, ResponseState } from './types';
+
+const initailState: ResponseState = {
+  responseId: null,
+  responseActive: false,
+};
+
+const response = createReducer<ResponseState, ResponseAction>(initailState, {
+  [RESPONSE_COMMENT]: (state, action) => ({
+    ...state,
+    responseId: action.payload,
+    responseActive: !state.responseActive,
+  }),
+});
+
+export default response;

--- a/src/modules/comments/types.ts
+++ b/src/modules/comments/types.ts
@@ -2,6 +2,7 @@ import { ActionType } from 'typesafe-actions';
 import * as actions from './actions';
 
 export type CommentsAction = ActionType<typeof actions>;
+export type ResponseAction = ActionType<typeof actions>;
 
 export type CommentInfo = {
   userid: number;
@@ -14,3 +15,8 @@ export type CommentInfo = {
 };
 
 export type CommentsInfoState = CommentInfo[];
+
+export type ResponseState = {
+  responseId: null | number;
+  responseActive: boolean;
+};

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,7 +1,8 @@
 import { combineReducers } from 'redux';
 import comments from './comments/reducer';
+import response from './comments/responseReducer';
 
-const rootReducer = combineReducers({ comments });
+const rootReducer = combineReducers({ comments, response });
 
 export default rootReducer;
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
1. 답장 버튼 클릭 시 해당 messagId값 전역상태값 관리 => redux 세팅
<br />
## :: 구현 사항 설명
1. 답장 버튼 클릭 시 해당 messageId값을 이용해서 responseId값을 만들어준다 이 responseId는 전역으로 관리되어 전송 버튼을 눌렀을 때 사용할 수 있다. 
<br />
